### PR TITLE
Add code for generating rollouts and script that generates them

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -17,6 +17,7 @@ dependencies:
       - tqdm
       - h5py
       - pytest
+      - fire
       # vision
       - transforms3d
       - opencv-python

--- a/examples/dough_model_learning/data_generation_utils.py
+++ b/examples/dough_model_learning/data_generation_utils.py
@@ -1,3 +1,4 @@
+import abc
 from dataclasses import dataclass
 import typing
 
@@ -140,3 +141,59 @@ class TransitionTupleDataset(torch.utils.data.TensorDataset):
         super(TransitionTupleDataset, self).__init__(
             current_heights, actions, next_heights
         )
+
+
+class GymAgent(abc.ABC):
+    """An agent in the Gym sense (as opposed to Sapien sense)."""
+
+    def reset(self):
+        pass
+
+    @abc.abstractmethod
+    def step(self, obs):
+        """Returns the action of the agent at this timestep."""
+        raise NotImplementedError
+
+
+class DoughRollingCenterOutAgent(GymAgent):
+    """Rolls dough starting from the center and moving outward."""
+
+    def __init__(
+        self,
+        duration: float = 1.0,
+        start_height: float = 0.06,
+        height_delta: float = 0.0025,
+    ):
+        self.duration = duration
+        self.start_height = start_height
+        self.height_delta = height_delta
+
+    def reset(self):
+        self.height = self.start_height
+
+    def step(self, obs):
+        height = self.height
+        self.height -= self.height_delta
+
+        start_position = [0, 0, height]
+        start_yaw = np.random.uniform(0, 2 * np.pi)
+        start_pitch = 0.0
+        rolling_distance = 0.1
+        delta_height = 0.0
+        delta_yaw = 0.0
+        delta_pitch = 0.0
+        action = np.concatenate(
+            (
+                [self.duration],
+                start_position,
+                [
+                    start_yaw,
+                    start_pitch,
+                    rolling_distance,
+                    delta_height,
+                    delta_yaw,
+                    delta_pitch,
+                ],
+            )
+        )
+        return action

--- a/examples/dough_model_learning/generate_dough_rolling_data.py
+++ b/examples/dough_model_learning/generate_dough_rolling_data.py
@@ -1,0 +1,73 @@
+"""Generates dough rolling data.
+
+TODO(blake.wulfe): Either improve this or use an existing framework for it.
+For now this is just draft code for generating data until we figure out how
+we actually want to do it. For example, this should probably use a config.
+We should probably plan out our requirements for the paper before doing this.
+
+To run this script (for example):
+```
+export CUDA_VISIBLE_DEVICES=0
+python examples/dough_model_learning/generate_dough_rolling_data.py \
+--output_filepath /path/to/where/to/store/data.npz \
+--num_episodes=1
+```
+"""
+import functools
+
+import fire
+
+from examples.dough_model_learning.data_generation_utils import (
+    DoughRollingCenterOutAgent,
+)
+
+from mani_skill2.envs.mpm.rolling_env import (
+    RollingEnv,
+    generate_circular_cone_heightmap,
+)
+from mani_skill2.utils.rollout import (
+    generate_rollouts,
+    save_rollouts,
+)
+
+
+def get_height_map_generator(radius=0.1, height=0.06):
+    return functools.partial(
+        generate_circular_cone_heightmap,
+        radius=radius,
+        height=height,
+    )
+
+
+def get_env(**kwargs):
+    return RollingEnv(**kwargs)
+
+
+def get_agent():
+    return DoughRollingCenterOutAgent()
+
+
+def main(
+    output_filepath,
+    num_episodes,
+    max_num_steps=5,
+    sim_freq=200,
+    mpm_freq=1000,
+    obs_height_map_dx=0.01,
+    obs_height_map_grid_size=(32, 32),
+):
+    height_map_generator = get_height_map_generator()
+    env = get_env(
+        sim_freq=sim_freq,
+        mpm_freq=mpm_freq,
+        dough_initializer=height_map_generator,
+        obs_height_map_dx=obs_height_map_dx,
+        obs_height_map_grid_size=obs_height_map_grid_size,
+    )
+    agent = get_agent()
+    rollouts = generate_rollouts(env, agent, num_episodes, max_num_steps)
+    save_rollouts(output_filepath, rollouts)
+
+
+if __name__ == "__main__":
+    fire.Fire(main)

--- a/examples/dough_model_learning/test/test_data_generation.py
+++ b/examples/dough_model_learning/test/test_data_generation.py
@@ -1,4 +1,4 @@
-import examples.dough_model_learning.data_generation as data_generation
+import examples.dough_model_learning.data_generation_utils as data_generation
 
 import unittest
 

--- a/examples/dough_model_learning/visualize_rollouts.py
+++ b/examples/dough_model_learning/visualize_rollouts.py
@@ -1,0 +1,52 @@
+import os
+
+import cv2
+import fire
+import imageio
+import numpy as np
+
+from mani_skill2.utils.rollout import load_rollouts
+
+
+def create_gif(imgs, filepath, duration=0.1):
+    assert filepath.endswith(".gif")
+    imageio.mimsave(filepath, imgs, duration=duration)
+
+
+def normalize_resize_heightmaps(heightmaps, max_height, resize):
+    normalized_heights = [(h / max_height * 255).astype(np.uint8) for h in heightmaps]
+    resized_heights = [cv2.resize(h, resize) for h in normalized_heights]
+    return resized_heights
+
+
+def create_heightmap_transition_gif(obs, next_obs, filepath, resize=(256, 256)):
+    max_height = np.max(obs)
+    obs = normalize_resize_heightmaps(obs, max_height, resize)
+    next_obs = normalize_resize_heightmaps(next_obs, max_height, resize)
+
+    transitions = []
+    for obs_i, next_obs_i in zip(obs, next_obs):
+        transition = np.hstack((obs_i, next_obs_i))
+        transitions.append(transition)
+    return create_gif(transitions, filepath, duration=0.5)
+
+
+def main(output_dir, data_filepath, max_num_episodes_to_visalize=5):
+    os.makedirs(output_dir, exist_ok=True)
+
+    tensors = load_rollouts(data_filepath)
+    # Get the indices where the episodes end
+    end_indices = np.where(tensors["trunc"])[0]
+    start = 0
+    for i, end in enumerate(end_indices):
+        filepath = os.path.join(output_dir, f"episode_{i:02d}.gif")
+        create_heightmap_transition_gif(
+            tensors["obs"][start : end + 1],
+            tensors["next_obs"][start : end + 1],
+            filepath,
+        )
+        start = end
+
+
+if __name__ == "__main__":
+    fire.Fire(main)

--- a/mani_skill2/envs/mpm/rolling_env.py
+++ b/mani_skill2/envs/mpm/rolling_env.py
@@ -98,10 +98,10 @@ def generate_flat_heightmap(dx, grid_size=(10, 10), height=0.01):
 class RollingEnv(MPMBaseEnv):
     agent: RollingPin
     action_option: ActionOption
-    dough_initializer: Callable
-    height_map_dx: float
-    obs_height_map_dx: float
-    obs_height_map_grid_size: Tuple[int, int]
+    _dough_initializer: Callable
+    _height_map_dx: float
+    _obs_height_map_dx: float
+    _obs_height_map_grid_size: Tuple[int, int]
 
     def __init__(
         self,
@@ -132,15 +132,18 @@ class RollingEnv(MPMBaseEnv):
 
         super().__init__(*args, **kwargs)
 
-    def reset(self, *args, regenerate_heigh_map=True, seed=None, **kwargs):
+    def reset(self, *args, regenerate_height_map=True, seed=None, **kwargs):
         """
         Args:
             regenerate_heigh_map: If True, generates a new height map. This is used
                 for testing purposes.
         """
-        if regenerate_heigh_map:
+        if regenerate_height_map:
             self._initial_height_map = self._dough_initializer(dx=self._height_map_dx)
-        return super().reset(*args, seed=seed, **kwargs)
+        super().reset(*args, seed=seed, **kwargs)
+        # TODO(blake.wulfe): Figure out how to integrate with super().reset() properly
+        # wrt the return value.
+        return self._get_obs()
 
     def _setup_mpm(self):
         self.model_builder = MPMModelBuilder()
@@ -692,7 +695,8 @@ class RollingEnv(MPMBaseEnv):
 
     def _get_obs(self):
         # TODO(blake.wulfe): Generalize this to different obs modes.
+        # See base env get_obs().
         return self.calc_heightmap(
             self._obs_height_map_dx,
             self._obs_height_map_grid_size,
-        )
+        ).height

--- a/mani_skill2/tests/envs/mpm/test_rolling_env.py
+++ b/mani_skill2/tests/envs/mpm/test_rolling_env.py
@@ -38,7 +38,7 @@ class TestRollingEnv(unittest.TestCase):
         )
         dx = 0.0025
         dut.set_initial_height_map(height, dx)
-        dut.reset(regenerate_heigh_map=False)
+        dut.reset(regenerate_height_map=False)
 
         height_map = dut.calc_heightmap(dx, height.shape)
         # MPMBuilder.add_mpm_from_height_map actually only set the height to `height` - dx, instead of the desired height.
@@ -187,7 +187,7 @@ class TestRollingEnv(unittest.TestCase):
         dut.set_initial_height_map(
             np.array([[0, 0, 0], [0, height, height], [0, height, height]]), dx
         )
-        dut.reset(regenerate_heigh_map=False)
+        dut.reset(regenerate_height_map=False)
         # Currently when we initialize the height map, the top cell
         # (with size dx * dx * dx) is always not filled. I should fix this bug.
         np.testing.assert_allclose(

--- a/mani_skill2/tests/utils/test_rollout.py
+++ b/mani_skill2/tests/utils/test_rollout.py
@@ -1,0 +1,59 @@
+import numpy as np
+import pytest
+
+from mani_skill2.utils.rollout import (
+    generate_rollouts,
+    load_rollouts,
+    rollout_episode,
+    save_rollouts,
+)
+
+EXPECTED_KEYS = ["obs", "action", "reward", "next_obs", "done", "trunc"]
+
+
+class MockEnv:
+    def reset(self):
+        return self._get_obs()
+
+    def step(self, action):
+        return self._get_obs(), 1, False, {}
+
+    def _get_obs(self):
+        return np.zeros((5, 5))
+
+
+class MockGymAgent:
+    def reset(self):
+        pass
+
+    def step(self, obs):
+        return 0
+
+
+@pytest.mark.parametrize("max_steps", [1, 2, 10])
+def test_rollout_episode(max_steps):
+    env = MockEnv()
+    agent = MockGymAgent()
+    rollout = rollout_episode(env, agent, max_steps=max_steps)
+    assert len(rollout["obs"]) == max_steps
+    for k in EXPECTED_KEYS:
+        assert k in rollout
+
+
+@pytest.mark.parametrize("num_episodes", [1, 2, 10])
+def test_generate_rollouts(num_episodes):
+    env = MockEnv()
+    agent = MockGymAgent()
+    rollouts = generate_rollouts(env, agent, num_episodes=num_episodes, max_steps=5)
+    assert len(rollouts) == num_episodes
+
+
+def test_save_and_load_rollouts(tmp_path):
+    env = MockEnv()
+    agent = MockGymAgent()
+    rollouts = generate_rollouts(env, agent, num_episodes=2, max_steps=5)
+    filepath = tmp_path / "test.npz"
+    save_rollouts(filepath, rollouts)
+    loaded = load_rollouts(filepath)
+    for k in EXPECTED_KEYS:
+        assert k in loaded

--- a/mani_skill2/utils/rollout.py
+++ b/mani_skill2/utils/rollout.py
@@ -1,0 +1,85 @@
+"""Functions relating to generating rollouts.
+
+TODO(blake.wulfe): Switch to some existing framework
+instead of rolling your own here.
+"""
+
+import collections
+
+import numpy as np
+
+
+def rollout_episode(env, agent, max_steps):
+    """Rolls out an episode in env with the agent.
+
+    Args:
+        env: Environment to roll out. Gym.Env interface expected.
+        agent: Agent to generate actions.
+        max_steps: Maximum number of steps to take in env.
+
+    Returns:
+        Dict with lists for relevant string keys.
+    """
+    traj = collections.defaultdict(list)
+
+    def add_step(**kwargs):
+        for k, v in kwargs.items():
+            traj[k].append(v)
+
+    agent.reset()
+    obs = env.reset()
+    for t in range(max_steps):
+        action = agent.step(obs)
+        next_obs, rew, done, info = env.step(action)
+
+        add_step(
+            obs=obs,
+            action=action,
+            reward=rew,
+            next_obs=next_obs,
+            done=done,
+            trunc=False,
+            info=info,
+        )
+
+        if done:
+            break
+        obs = next_obs
+    else:
+        # Runs at the end of the for loop if there wasn't a break.
+        assert len(traj["trunc"]) > 0
+        traj["trunc"][-1] = True
+
+    assert len(traj["obs"]) > 0
+    return traj
+
+
+def generate_rollouts(env, agent, num_episodes, max_steps):
+    trajs = []
+    for i in range(num_episodes):
+        traj = rollout_episode(env, agent, max_steps)
+        trajs.append(traj)
+    return trajs
+
+
+def convert_rollouts_to_tensor_dict(trajs):
+    stacked = collections.defaultdict(list)
+    for traj in trajs:
+        for k, v in traj.items():
+            stacked[k].extend(v)
+
+    tensors = dict()
+    for k, v in stacked.items():
+        tensors[k] = np.array(v)
+
+    return tensors
+
+
+def save_rollouts(filepath, trajs):
+    tensors = convert_rollouts_to_tensor_dict(trajs)
+    np.savez(filepath, **tensors)
+
+
+def load_rollouts(filepath):
+    tensors = np.load(filepath, allow_pickle=True)
+    return dict(tensors)


### PR DESCRIPTION
The rollout code is library code with tests. Ultimately we should replace this with something from some existing library. I'm taking the approach in this commit for now in order to decouple progress on the model from progress on the infrastructure side.

Then there are a couple scripts for generating data and visualizing it. These don't have tests since they're not part of the library code. I'll include some visualizations, though.