### PR TITLE
Add an option to only impose the reward at the final state/action of the rollout

### DIFF
--- a/mani_skill2/algorithms/action_samplers.py
+++ b/mani_skill2/algorithms/action_samplers.py
@@ -79,8 +79,8 @@ class RandomDoughRollingActionSampler:
         """
         Return the lower and upper bounds of the action
         """
-        lower_bound = torch.full((self.action_size,), -np.inf, device=self.device)
-        upper_bound = torch.full((self.action_size,), np.inf, device=self.device)
+        lower_bound = torch.full((self.action_size,), 0.0, device=self.device)
+        upper_bound = torch.full((self.action_size,), 0.0, device=self.device)
         lower_bound[0] = self.rolling_duration_bounds[0]
         upper_bound[0] = self.rolling_duration_bounds[1]
         lower_bound[3] = self.height_bounds[0]

--- a/mani_skill2/envs/mpm/rolling_env.py
+++ b/mani_skill2/envs/mpm/rolling_env.py
@@ -492,7 +492,7 @@ class RollingEnv(MPMBaseEnv):
         """
         p_Wpin_init = start_pose.p
         R_Wpin_init = transforms3d.quaternions.quat2mat(start_pose.q)
-        if not self.is_pin_y_horizontal(R_Wpin_init, 1e-3):
+        if not self.is_pin_y_horizontal(R_Wpin_init, 1e-2):
             raise Exception(
                 "RollingPinEnv.step(): pin y axis should be perpendicular to world z axis."
             )

--- a/mani_skill2/tests/dynamics/test_generative_env.py
+++ b/mani_skill2/tests/dynamics/test_generative_env.py
@@ -3,6 +3,7 @@ import pytest
 import numpy as np
 import torch
 
+from mani_skill2.dynamics.generative_env import RewardOption
 from mani_skill2.utils.testing.dynamics_test_utils import MockGenerativeEnv
 
 
@@ -27,21 +28,46 @@ class TestGenerativeEnv:
     @pytest.mark.parametrize("steps", (1, 5))
     @pytest.mark.parametrize("batch_size", (1, 4))
     @pytest.mark.parametrize("device", ("cpu", "cuda"))
-    def test_rollout(self, state_size, act_size, steps, batch_size, device):
+    @pytest.mark.parametrize(
+        "reward_option", (RewardOption.Always, RewardOption.FinalTimeOnly)
+    )
+    def test_rollout(
+        self, state_size, act_size, steps, batch_size, device, reward_option
+    ):
         torch.random.manual_seed(123)
-        generative_env = MockGenerativeEnv(state_size, act_size)
-        generative_env.dynamics_model.to(device)
-        generative_env.reward_model.to(device)
+        dut = MockGenerativeEnv(state_size, act_size, device, reward_option)
+        dut.dynamics_model.to(device)
+        dut.reward_model.to(device)
 
         discount_factor = 0.5
         state_init = torch.rand((batch_size, state_size), device=device)
         act_sequence = torch.rand((batch_size, steps, act_size), device=device)
-        states, reward, info = generative_env.rollout(
-            state_init, act_sequence, discount_factor
-        )
+        states, reward, info = dut.rollout(state_init, act_sequence, discount_factor)
         assert states.shape == (batch_size, steps + 1, state_size)
         np.testing.assert_allclose(
             states[:, 0, :].detach().cpu().numpy(), state_init.detach().cpu().numpy()
         )
         assert reward.shape == (batch_size,)
+        reward_per_step = torch.zeros((batch_size, steps), device=device)
+        for i in range(steps):
+            reward_per_step[:, i], _ = dut.reward_model.step(
+                states[:, i, :], dut.observation(states[:, i, :]), act_sequence[:, i, :]
+            )
+        if reward_option == RewardOption.Always:
+            reward_expected = torch.sum(
+                reward_per_step
+                * torch.pow(
+                    discount_factor * torch.ones((batch_size, steps), device=device),
+                    torch.arange(0, steps, device=device).repeat((batch_size, 1)),
+                ),
+                dim=-1,
+            )
+        elif reward_option == RewardOption.FinalTimeOnly:
+            reward_expected = reward_per_step[:, -1]
+        np.testing.assert_allclose(
+            reward.cpu().detach().numpy(),
+            reward_expected.cpu().detach().numpy(),
+            atol=1e-5,
+        )
+
         assert isinstance(info, dict)

--- a/mani_skill2/utils/testing/dynamics_test_utils.py
+++ b/mani_skill2/utils/testing/dynamics_test_utils.py
@@ -6,7 +6,7 @@ from ray.rllib.policy.sample_batch import SampleBatch
 import torch
 import torch.nn as nn
 
-from mani_skill2.dynamics.generative_env import GenerativeEnv
+from mani_skill2.dynamics.generative_env import GenerativeEnv, RewardOption
 from mani_skill2.dynamics.network_dynamics_model import NetworkDynamicsModel
 from mani_skill2.dynamics.normalizers import Normalizer
 from mani_skill2.dynamics.reward import GoalBasedRewardModel
@@ -55,7 +55,7 @@ class MockRewardModel(GoalBasedRewardModel):
         obs: torch.Tensor,
         action: torch.Tensor,
     ) -> Tuple[torch.Tensor, Dict]:
-        reward = ((self.goal - state) ** 2).sum(dim=-1) + (action ** 2).sum(dim=-1)
+        reward = ((self.goal - state) ** 2).sum(dim=-1) + (action**2).sum(dim=-1)
         return reward, dict()
 
     def set_goal(self, goal: torch.Tensor):
@@ -66,7 +66,9 @@ class MockGenerativeEnv(GenerativeEnv):
     dynamics_model: NetworkDynamicsModel
     reward_model: MockRewardModel
 
-    def __init__(self, state_size, act_size, device="cpu"):
+    def __init__(
+        self, state_size, act_size, device="cpu", reward_option=RewardOption.Always
+    ):
         self.dynamics_model = NetworkDynamicsModel(
             MockFCNetwork(state_size, act_size), is_residual=True
         )
@@ -75,6 +77,7 @@ class MockGenerativeEnv(GenerativeEnv):
         self.reward_model.to(device)
         self.state_size = state_size
         self.act_size = act_size
+        self.reward_option = reward_option
 
     def reset(self) -> torch.Tensor:
         return torch.zeros(self.state_size)


### PR DESCRIPTION
So that we have a sparse reward.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hongkai-dai/ManiSkill2/27)
<!-- Reviewable:end -->
