### PR TITLE
reward depends on both current and the next state.

### DIFF
--- a/mani_skill2/algorithms/action_samplers.py
+++ b/mani_skill2/algorithms/action_samplers.py
@@ -85,6 +85,8 @@ class RandomDoughRollingActionSampler:
         upper_bound[0] = self.rolling_duration_bounds[1]
         lower_bound[3] = self.height_bounds[0]
         upper_bound[3] = self.height_bounds[1]
+        lower_bound[4] = 0
+        upper_bound[4] = 2 * np.pi
         lower_bound[6] = self.rolling_distance_bounds[0]
         upper_bound[6] = self.rolling_distance_bounds[1]
         return (lower_bound, upper_bound)

--- a/mani_skill2/algorithms/gradient_shooting.py
+++ b/mani_skill2/algorithms/gradient_shooting.py
@@ -152,7 +152,7 @@ class GradientShootingAgent(GymAgent):
         # Deep copy self.act_sequences so that this step() function does not modify the
         # class data.
         act_sequences = copy.deepcopy(self.act_sequences)
-        optimizer = self.optimizer([act_sequences], lr=1e-1)
+        optimizer = self.optimizer([act_sequences])
         initial_state = self.generative_env.dynamics_model.state_from_observation(
             obs
         ).to(self.device)

--- a/mani_skill2/dynamics/generative_env.py
+++ b/mani_skill2/dynamics/generative_env.py
@@ -61,7 +61,8 @@ class GenerativeEnv:
         """
         next_state, terminated, info = self.dynamics_model.step(state, action)
         obs = self.observation(state)
-        reward, _ = self.reward_model.step(state, obs, action)
+        next_obs = self.observation(obs)
+        reward, _ = self.reward_model.step(state, obs, next_state, next_obs, action)
         return next_state, reward, terminated, info
 
     @abc.abstractmethod

--- a/mani_skill2/dynamics/reward.py
+++ b/mani_skill2/dynamics/reward.py
@@ -14,6 +14,8 @@ class GoalBasedRewardModel(abc.ABC, torch.nn.Module):
         self,
         state: torch.Tensor,
         obs: torch.Tensor,
+        next_state: torch.Tensor,
+        next_obs: torch.Tensor,
         action: torch.Tensor,
     ) -> Tuple[torch.Tensor, Dict]:
         """
@@ -22,6 +24,8 @@ class GoalBasedRewardModel(abc.ABC, torch.nn.Module):
         Args:
             state (torch.Tensor): The state at the start of the transition.
             obs (torch.Tensor): The observation at the start of the transition.
+            next_state (torch.Tensor): The state at the end of the transition.
+            next_obs (torch.Tensor): The observation at the end of the transition.
             action (torch.Tensor): The action during the transition.
 
         Returns:

--- a/mani_skill2/tests/algorithms/test_random_shooting.py
+++ b/mani_skill2/tests/algorithms/test_random_shooting.py
@@ -57,13 +57,20 @@ class TestRandomShootingAgent:
                 state_sequence[i], act_sequence[i]
             )
             obs_i = generative_env.dynamics_model.observation(state_sequence[i])
+            obs_i_plus_1 = generative_env.dynamics_model.observation(
+                state_sequence[i + 1]
+            )
             np.testing.assert_allclose(
                 state_sequence[i + 1].cpu().detach().numpy(),
                 next_state.cpu().detach().numpy(),
                 atol=1e-6,
             )
             reward, _ = generative_env.reward_model.step(
-                state_sequence[i], obs_i, act_sequence[i]
+                state_sequence[i],
+                obs_i,
+                state_sequence[i + 1],
+                obs_i_plus_1,
+                act_sequence[i],
             )
-            reward_expected += reward * discount_factor ** i
+            reward_expected += reward * discount_factor**i
         np.testing.assert_allclose(best_reward.item(), reward_expected.item())

--- a/mani_skill2/tests/dynamics/test_generative_env.py
+++ b/mani_skill2/tests/dynamics/test_generative_env.py
@@ -51,7 +51,11 @@ class TestGenerativeEnv:
         reward_per_step = torch.zeros((batch_size, steps), device=device)
         for i in range(steps):
             reward_per_step[:, i], _ = dut.reward_model.step(
-                states[:, i, :], dut.observation(states[:, i, :]), act_sequence[:, i, :]
+                states[:, i, :],
+                dut.observation(states[:, i, :]),
+                states[:, i + 1, :],
+                dut.observation(states[:, i + 1, :]),
+                act_sequence[:, i, :],
             )
         if reward_option == RewardOption.Always:
             reward_expected = torch.sum(

--- a/mani_skill2/utils/testing/dynamics_test_utils.py
+++ b/mani_skill2/utils/testing/dynamics_test_utils.py
@@ -53,6 +53,8 @@ class MockRewardModel(GoalBasedRewardModel):
         self,
         state: torch.Tensor,
         obs: torch.Tensor,
+        next_state: torch.Tensor,
+        next_obs: torch.Tensor,
         action: torch.Tensor,
     ) -> Tuple[torch.Tensor, Dict]:
         reward = ((self.goal - state) ** 2).sum(dim=-1) + (action**2).sum(dim=-1)


### PR DESCRIPTION
Now use a sparse reward (only the final state shape error):

This is the desired heightmap
![dough_desired](https://user-images.githubusercontent.com/6314000/228417467-c8d3543c-f201-46be-88f3-5fd54c149262.png)

Here is the rollout from the initial guess
![dough_t0_init0](https://user-images.githubusercontent.com/6314000/228417515-3bf85527-186e-4f50-b785-c6b078c4800b.png)
![dough_t0_init1](https://user-images.githubusercontent.com/6314000/228417526-1389073d-5247-47c9-9e6e-df27117350b5.png)

![dough_t0_init2](https://user-images.githubusercontent.com/6314000/228417531-5f694d46-d928-4a68-81f5-81100f2616d5.png)

And here is the rollout from the optimized action:
![dough_t0_optimized0](https://user-images.githubusercontent.com/6314000/228417563-fb349e32-4806-47b6-8ac3-577b9fe0beab.png)
![dough_t0_optimized1](https://user-images.githubusercontent.com/6314000/228417591-8b78df24-3e73-451b-9d75-e441322cc72a.png)
![dough_t0_optimized2](https://user-images.githubusercontent.com/6314000/228417598-feacdade-c92d-47cb-b69c-c2c8748348de.png)

Here is the reward during optimization
![dough_0_reward](https://user-images.githubusercontent.com/6314000/228417628-623b9b88-5064-4d79-890a-6ea4f4ea6734.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hongkai-dai/ManiSkill2/28)
<!-- Reviewable:end -->
